### PR TITLE
Remove warnings

### DIFF
--- a/lib/exchema_json.ex
+++ b/lib/exchema_json.ex
@@ -14,19 +14,19 @@ defmodule ExchemaJSONish do
     end
   end
 
-  defp do_encode(nil, overrides), do: nil
+  defp do_encode(nil, _overrides), do: nil
 
-  defp do_encode(input, overrides) when is_atom(input),
+  defp do_encode(input, _overrides) when is_atom(input),
     do: to_string(input)
 
-  defp do_encode(input, overrides) when is_number(input) or is_binary(input),
+  defp do_encode(input, _overrides) when is_number(input) or is_binary(input),
     do: input
 
-  defp do_encode(%mod{} = input, overrides)
+  defp do_encode(%mod{} = input, _overrides)
       when mod in [DateTime, NaiveDateTime, Time, Date],
       do: mod.to_iso8601(input)
 
-  defp do_encode(%mod{} = input, overrides) do
+  defp do_encode(%_mod{} = input, overrides) do
     input
     |> Map.from_struct()
     |> encode(overrides)

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
-  "exchema": {:hex, :exchema, "0.3.0", "ca61128b1c84786c2259f20b2e2d7da5c99cdfe7b6adf91abedf28e2734b4026", [:mix], [], "hexpm"},
-  "exchema_coercion": {:git, "https://github.com/bamorim/exchema_coercion.git", "82dfdada87b0aa66fd9cccee6d7439c26d90c189", []},
-  "exchema_stream_data": {:git, "https://github.com/bamorim/exchema_stream_data.git", "2fa591b86f8dd87f3e8ab0a233f356dc5bf5a0a4", []},
+  "exchema": {:hex, :exchema, "0.4.0", "a978535ad9a40201c2ac3c10e73a4cf7cebceb666ec1b8ea1f179b7b9dcc059e", [:mix], [], "hexpm"},
+  "exchema_coercion": {:git, "https://github.com/bamorim/exchema_coercion.git", "8c580c5498979b88dd8bc015bc101606a3be97dd", []},
+  "exchema_stream_data": {:git, "https://github.com/bamorim/exchema_stream_data.git", "e662a01fae5890e6ef3d7009eb9b03693c877527", []},
   "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This PR removes warnings from unused vars and updates the lock file, that wasn't updated whe the exschema version was updated